### PR TITLE
feat: adiciona prop 'icon' em ani-button

### DIFF
--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -38,10 +38,12 @@ O componente Button pode ser personalizado com as seguintes propriedades:
 
 - `disabled` (opcional): se o botão estiver desativado ou não. O valor padrão é `false`.
 
+- `icon` (opcional): o nome do ícone a ser exibido no botão. O componente `ani-icon` deve ser importado e configurado separadamente para que o ícone seja exibido.
+
 Você pode definir essas propriedades diretamente no componente Button, como segue:
 
 ```html
-<ani-button variant="secondary" size="large" disabled>
+<ani-button variant="secondary" size="large" disabled icon="arrow-right">
   Meu botão desativado
 </ani-button>
 ```
@@ -50,15 +52,15 @@ Isso criará um botão com a variante "secondary", o tamanho "large" e que está
 
 ## Ícones
 
-Além de texto, o botão também pode exibir em seu conteúdo texto e ícone ou apenas um ícone. Para isso você deve incluir o ícone como um elemento filho do componente `Button`. Por exemplo:
+Além de texto, o botão também pode exibir em seu conteúdo texto e ícone ou apenas um ícone. Para isso você deve incluir o ícone como um valor da propriedade `icon` do componente `ani-button`. Por exemplo:
 
 ```html
-<ani-button>
-  <ani-icon name="arrow-right"></ani-icon>
-</ani-button>
+<ani-button icon="arrow-right"></ani-button>
 ```
 
 Isso criará um botão com apenas um ícone "arrow-right".
+
+Você pode usar qualquer ícone suportado pelo componente `ani-icon`, basta especificar o nome do ícone na propriedade `icon`.
 
 ## Eventos
 

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -26,6 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@animaliads/ani-icon": "^1.1.0-dev.40",
     "@animaliads/common": "^1.1.0-dev.45"
   },
   "publishConfig": {

--- a/packages/button/src/button.style.ts
+++ b/packages/button/src/button.style.ts
@@ -12,6 +12,10 @@ export const style = `
     border-style: solid;
     min-height: 2.75em;
     cursor: pointer;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   button[size='small'], button[size='medium'], button[size='large'] {
@@ -149,4 +153,7 @@ export const style = `
     background-color: transparent;
   }
 
+  button ani-icon {
+    margin-right: 0.5em; /* Adicionado */
+  }
 `;

--- a/packages/button/src/button.ts
+++ b/packages/button/src/button.ts
@@ -46,8 +46,12 @@ export class Button extends HTMLElement {
     return !type || type === 'null' ? ButtonType.button : type;
   }
 
+  get icon(): string {
+    return this.getAttribute('icon');
+  }
+
   static get observedAttributes(): Array<string> {
-    return ['kind', 'disabled', 'danger', 'type', 'size'];
+    return ['kind', 'disabled', 'danger', 'type', 'size', 'icon'];
   }
 
   connectedCallback(): void {
@@ -98,16 +102,21 @@ export class Button extends HTMLElement {
   }
 
   private render(): void {
+    const iconElement = this.icon
+      ? `<ani-icon name="${this.icon}"></ani-icon>`
+      : '';
+
     this.shadow.innerHTML = `
-            <style>${style}</style>
-            <button
-              type="${this.type}"
-              kind=${this.kind}
-              size=${this.size}
-              ${this.disabled === 'true' ? 'disabled' : ''}
-              danger=${this.danger}>
-                <slot></slot>
-            </button>
-        `;
+      <style>${style}</style>
+      <button
+        type="${this.type}"
+        kind=${this.kind}
+        size=${this.size}
+        ${this.disabled === 'true' ? 'disabled' : ''}
+        danger=${this.danger}>
+          ${iconElement}
+          <slot></slot>
+      </button>
+    `;
   }
 }

--- a/packages/button/src/stories/button.stories.ts
+++ b/packages/button/src/stories/button.stories.ts
@@ -68,6 +68,16 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    icon: {
+      control: 'text',
+      description: 'Nome do ícone a ser exibido no botão.',
+      defaultValue: '',
+      table: {
+        type: { summary: 'string' },
+        category: 'Propriedades',
+        defaultValue: { summary: '' },
+      },
+    },
     onClick: {
       description: 'Evento disparado ao clicar no botão.',
       table: {
@@ -83,7 +93,7 @@ export default {
   },
 };
 
-const Template = ({ label, ...args }) => {
+const Template = ({ label, icon, ...args }) => {
   return html`
     <ani-button
       kind="${args.kind}"
@@ -91,6 +101,7 @@ const Template = ({ label, ...args }) => {
       danger="${args.danger}"
       size="${args.size}"
       disabled="${args.disabled}"
+      icon="${icon}"
     >
       ${label}
     </ani-button>


### PR DESCRIPTION
## Adiciona propriedade `icon` em `ani-button`.

Nova propriedade do tipo `icon` em `ani-button` para a utilização de ícones em forma de propriedade. :cherry_blossom:

```html
<ani-button icon="arrow-right">Abacate</ani-button>
```

resultado:

![image](https://user-images.githubusercontent.com/39086256/230479470-4c8ebf48-461e-4cf3-bb41-2c6f8d1217a0.png)


### Como revisar

- Testar no labs do storybook

#### Para os devs

- Clonar o repositório
- `npm i`
- `npx lerna bootstrap`
- `npx lerna run build`

Adicionar o seletor do componente no arquivo `animalia-web-components/demo/app/index.html`, da seguinte forma:

```html
<ani-button icon="arrow-right">Abacate</ani-button>
```

Depois execute o comando:

```
npx lerna run start
```

Que irá abrir uma janela no seu navegador com o app de demonstração do componente.
