### PR TITLE
feat: adiciona error text em textfield

### DIFF
--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -1,26 +1,72 @@
 # `<ani-textfield>`
 
-Componente de textfield desenvolvido com [Web Components](https://developer.mozilla.org/pt-BR/docs/Web/Web_Components).
+O componente `ani-textfield` (desenvolvido com [Web Components](https://developer.mozilla.org/pt-BR/docs/Web/Web_Components)) é usado para criar campos de texto interativos em um aplicativo da web. Ele pode ser personalizado com diferentes propriedades para atender às necessidades do seu projeto.
 
 ## Instalação
+
+Para instalar o componente Textfield, você pode usar o gerenciador de pacotes npm. Execute o seguinte comando no terminal:
 
 ```
 npm i @animaliads/ani-textfield
 ```
 
-## Utilização
+## Como usar
 
+Para usar o componente Textfield em seu projeto, importe-o no seu código:
+
+```ts
+import '@animalia-web-components/textfield';
 ```
-<ani-textfield></ani-textfield>
+
+Em seguida, você pode usar o componente em seu HTML como segue:
+
+```html
+<ani-textfield label="Nome" placeholder="Digite seu nome"></ani-textfield>
 ```
+
+Isso criará um campo de texto com o rótulo "Nome" e uma dica "Digite seu nome".
 
 ## Propriedades
 
-[EM BREVE]
+O componente Textfield pode ser personalizado com as seguintes propriedades:
+
+- `label` (obrigatório): o rótulo do campo de texto. Deve ser fornecido como um atributo HTML.
+
+- `placeholder` (opcional): uma dica para o usuário. Pode ser usado para fornecer informações adicionais sobre o campo de texto.
+
+- `value` (opcional): o valor atual do campo de texto.
+
+- `disabled` (opcional): se o campo de texto estiver desativado ou não. O valor padrão é `false`.
+
+- `readonly` (opcional): se o campo de texto for somente leitura ou não. O valor padrão é `false`.
+
+- `required` (opcional): se o campo de texto for obrigatório ou não. O valor padrão é `false`.
+
+- `pattern` (opcional): uma expressão regular que o valor do campo de texto deve corresponder.
+
+- `type` (opcional): o tipo do campo de texto. Pode ser "text" (padrão), "email", "password" ou "number".
+
+- `error` (opcional): texto de erro exibido quando houver algum erro no campo.
+
+Você pode definir essas propriedades diretamente no componente Textfield, como segue:
+
+```html
+<ani-textfield label="Senha" type="password" required></ani-textfield>
+```
+
+Isso criará um campo de texto do tipo "password" com o rótulo "Senha" e que é obrigatório.
 
 ## Eventos
 
-[EM BREVE]
+O componente `ani-textfield` dispara eventos quando o usuário interage com ele. Você pode ouvir esses eventos no seu código usando as funções `addEventListener` ou `onEventName`. Os eventos suportados são:
+
+- `change`: disparado quando o valor do campo de texto é alterado.
+
+- `focus`: disparado quando o campo de texto recebe o foco.
+
+- `blur`: disparado quando o campo de texto perde o foco.
+
+- `keydown`: disparado quando uma tecla é pressionada enquanto o campo de texto está em foco.
 
 ## Customização
 

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -29,6 +29,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@animaliads/ani-icon": "^1.1.0-dev.40",
     "@animaliads/common": "^1.1.0-dev.45"
   }
 }

--- a/packages/textfield/src/stories/textfield.stories.ts
+++ b/packages/textfield/src/stories/textfield.stories.ts
@@ -143,6 +143,14 @@ export default {
         category: 'Eventos',
       },
     },
+    error: {
+      control: 'text',
+      description: 'Texto de erro exibido quando houver algum erro no campo.',
+      table: {
+        type: { summary: 'string' },
+        category: 'Propriedades',
+      },
+    },
   },
 };
 
@@ -159,6 +167,7 @@ const Template = ({ label, ...args }) => {
       required="${args.required}"
       readonly="${args.readonly}"
       disabled="${args.disabled}"
+      error="${args.error}"
     >
       ${label}
     </ani-textfield>
@@ -177,6 +186,7 @@ Sample.args = {
   required: false,
   readonly: false,
   disabled: false,
+  error: '',
   label: '',
 };
 
@@ -195,6 +205,7 @@ Sample.parameters = {
   required="${Sample.required}"
   readonly="${Sample.readonly}"
   disabled="${Sample.disabled}"
+  error="${Sample.error}"
 >
 ${Sample.args.label}
 </ani-textfield>`,

--- a/packages/textfield/src/style.ts
+++ b/packages/textfield/src/style.ts
@@ -49,4 +49,16 @@ input:disabled {
 
     cursor: not-allowed;
 }
+
+.error {
+    display: none;
+    align-items: center;
+    color: var(--error-color);
+    margin-top: var(--error-text-margin);
+}
+
+.error-text {
+    margin-left: var(--error-text-margin);
+    margin-bottom: var(--error-text-margin);
+}
 `;

--- a/packages/textfield/src/textfield.ts
+++ b/packages/textfield/src/textfield.ts
@@ -58,6 +58,14 @@ export default class Textfield extends HTMLElement {
     return transformBooleanProperties(readonly);
   }
 
+  get error(): string {
+    return this.getAttribute('error') || '';
+  }
+
+  set error(value: string) {
+    this.setAttribute('error', value);
+  }
+
   static get observedAttributes(): Array<string> {
     return [
       'pattern',
@@ -70,6 +78,7 @@ export default class Textfield extends HTMLElement {
       'maxlength',
       'minlength',
       'value',
+      'error',
     ];
   }
 
@@ -96,6 +105,17 @@ export default class Textfield extends HTMLElement {
 
   attributeChangedCallback(): void {
     this.updateAttributes();
+
+    if (this.shadowRoot) {
+      const errorTextElement = this.shadowRoot.querySelector(
+        '.error-text'
+      ) as HTMLElement;
+      const errorElement = this.shadowRoot.querySelector(
+        '.error'
+      ) as HTMLElement;
+      errorTextElement.textContent = this.error;
+      errorElement.style.display = this.error ? 'flex' : 'none';
+    }
   }
 
   /**
@@ -120,6 +140,10 @@ export default class Textfield extends HTMLElement {
             <slot></slot>
           </div>
           <input />
+          <span class="error">
+            <ani-icon class="error-icon" size="small" name="info"></ani-icon>
+            <span class="error-text">${this.error}</span>
+          </span>
         </label>
     `;
   }
@@ -144,6 +168,12 @@ export default class Textfield extends HTMLElement {
     this.textfieldElement.readOnly = this.readonly === 'true';
     this.textfieldElement.disabled = this.disabled === 'true';
     this.textfieldElement.required = this.required === 'true';
+    this.updateErrorText();
+  }
+
+  private updateErrorText() {
+    const errorElement = this.shadowRoot.querySelector('.error-text');
+    errorElement.textContent = this.error;
   }
 
   updateAttribute(attr: string, property: string): void {


### PR DESCRIPTION
## `ani-textfield` - adiciona nova propriedade `error`

Adiciona nova propriedade de `error-text` no textfield.

### Como revisar

- Testar no labs do storybook 

#### Para os devs

- Clonar o repositório
- `npm i`
- `npx lerna bootstrap`
- `npx lerna run build`

Adicionar o seletor do componente no arquivo `animalia-web-components/demo/app/index.html`, da seguinte forma:

```html
<ani-textfield error="mensagem de erro"></ani-textfield>
```

Depois execute o comando:

```
npx lerna run start
```

Que irá abrir uma janela no seu navegador com o app de demonstração do componente.

PR animalia brand: [feat: adiciona variáveis de error-text em textfield](https://github.com/animaliads/animalia-brand/pull/22)
